### PR TITLE
estimatedTimeOfArrival, timeToGo and eta are calculated incorrectly in eta.js - Issue #133

### DIFF
--- a/calcs/eta.js
+++ b/calcs/eta.js
@@ -19,7 +19,7 @@ module.exports = function (app) {
 
       var datems = date.getTime()
       var timetopoint = Math.floor(
-        distance / (velocityMadeGood * 0.514444) * 1000
+        distance / velocityMadeGood * 1000
       )
 
       //      app.debug(`Using datetime: ${date} ms to point : ${timetopoint} currentms: ${datems}`)


### PR DESCRIPTION
the calculation uses:
distance / (velocityMadeGood * 0.514444) * 1000

this assumes that VMG is in kts when it is (and should be) in m/s.

The 0.514444 should be removed from the calc on line 22